### PR TITLE
Adds grunt-task for gh-pages docs release.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,6 +122,12 @@ module.exports = function( grunt ) {
       clean: {
          docco: ['docs'],
       },
+      'gh-pages': {
+         options: {
+            base: 'docs'
+         },
+         src: ['**']
+      },
       rename: {
          docco: {
             files: [
@@ -170,7 +176,6 @@ module.exports = function( grunt ) {
    grunt.registerTask( "test-em", ["jsonlint", "concat", "jshint", "uglify", "cssmin", "copy", "testem"] );
    grunt.registerTask( "travis", ["jsonlint", "jshint", "jasmine"] );
    grunt.registerTask( "dist", ["jsonlint", "concat", "jshint", "uglify", "cssmin", "copy"] );
-   grunt.registerTask( "dist-docs", ["jsonlint", "concat", "jshint", "uglify", "cssmin", "copy", "clean:docco", "docco", "rename:docco"] );
    grunt.registerTask( "docs", ["clean:docco", "docco", "rename:docco"] );
-
+   grunt.registerTask( "gh-docs", ["clean:docco", "docco", "rename:docco", "gh-pages"] );
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.4.4",
     "grunt-docco": "latest",
+    "grunt-gh-pages": "^0.9.1",
     "grunt-jsonlint": "~1.0.0",
     "grunt-testem": "latest",
     "load-grunt-config": "^0.13.1"


### PR DESCRIPTION
:bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: 
# Adds automatic GitHub pages release task

This branch adds a grunt-plugin to automatically push `/docs` to the `gh-pages` branch.
## Pull request contains the following changes:
1. Removes `dist-docs` task as it is a aggregation of `dist` and `docs`
   - Running them separately shouldn't cause massive pain
2. Adds a grunt-plugin `gh-pages` bound to task `gh-docs`
   - So first run task `docs` then `gh-docs` via grunt and everything from `/docs` will automagically be pushed to the `gh-pages` branch

`$ npm update` needed to install the grunt plugin! 

:bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: :bomb: 
